### PR TITLE
fix admin campaign rule view

### DIFF
--- a/app/helpers/admin/campaign_rules_helper.rb
+++ b/app/helpers/admin/campaign_rules_helper.rb
@@ -1,6 +1,6 @@
 module Admin::CampaignRulesHelper
-  def options_for_campaign_discount_types(discount_types)
-    options_for_select(discount_types.map { |key| [t("models.campaign_rules.discount_type.#{key}"), key] })
+  def options_for_campaign_discount_types(discount_types, selected=nil)
+    options_for_select(discount_types.map { |key| [t("models.campaign_rules.discount_type.#{key}"), key] }, selected: selected)
   end
 
   def options_for_campaign_rule_types

--- a/app/views/admin/campaign_rules/_campaign_rule_form.html.haml
+++ b/app/views/admin/campaign_rules/_campaign_rule_form.html.haml
@@ -29,7 +29,7 @@
 .form-group
   = f.label :discount_type, "優惠類型", class: "col-sm-2 control-label"
   .col-sm-10
-    = f.select :discount_type, options_for_campaign_discount_types(discount_types), {}, { class: "form-control", disabled: f.object.persisted? }
+    = f.select :discount_type, options_for_campaign_discount_types(discount_types, discount_type), {}, { class: "form-control", disabled: f.object.persisted? }
 .form-group.discount-type{"data-type": "money_off", class: "#{'hidden' if discount_type != "money_off"}"}
   = f.label :discount_money, "優惠金額", class: "col-sm-2 control-label"
   .col-sm-10

--- a/app/views/admin/campaign_rules/edit.html.haml
+++ b/app/views/admin/campaign_rules/edit.html.haml
@@ -12,4 +12,4 @@
         %h3 編輯優惠活動
     .panel-body
       = form_for @campaign_rule, url: admin_campaign_rule_path(@campaign_rule), method: 'patch', html: { class: "form-horizontal"} do |f|
-        = render "campaign_rule_form", f: f, discount_types: CampaignRule.discount_types,discount_type: @campaign_rule.discount_type, rule_type: @campaign_rule.rule_type
+        = render "campaign_rule_form", f: f, discount_types: CampaignRule.discount_types.keys,discount_type: @campaign_rule.discount_type, rule_type: @campaign_rule.rule_type

--- a/app/views/admin/campaign_rules/new.html.haml
+++ b/app/views/admin/campaign_rules/new.html.haml
@@ -12,4 +12,4 @@
         %h3 新增優惠活動
     .panel-body
       = form_for @campaign_rule, url: admin_campaign_rules_path, html: { class: "form-horizontal"} do |f|
-        = render "campaign_rule_form", f: f, discount_types: CampaignRule::DISCOUNT_MONEY_TYPE,discount_type: "money_off", rule_type: "exceed_amount"
+        = render "campaign_rule_form", f: f, discount_types: CampaignRule::DISCOUNT_MONEY_TYPE, discount_type: "money_off", rule_type: "exceed_amount"


### PR DESCRIPTION
修正bug: 後台優惠活動新增編輯的優惠類型
原本：
<img width="685" alt="screen shot 2016-10-25 at 2 45 57 pm" src="https://cloud.githubusercontent.com/assets/13852334/19675607/c5899a22-9ac1-11e6-9c66-22b50df748fe.png">
修正後：
<img width="742" alt="screen shot 2016-10-25 at 2 45 36 pm" src="https://cloud.githubusercontent.com/assets/13852334/19675606/c5874fec-9ac1-11e6-8e87-75895865920e.png">
